### PR TITLE
added "glad/include" to ImGui include directories

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,5 +17,5 @@ target_sources(imgui
             imgui/backends/imgui_impl_opengl3.cpp
             imgui/backends/imgui_impl_glfw.cpp)
 
-target_include_directories(imgui SYSTEM PUBLIC imgui imgui/backends)
+target_include_directories(imgui SYSTEM PUBLIC imgui imgui/backends "glad/include")
 target_link_libraries(imgui glfw OpenGL::GL)


### PR DESCRIPTION
Now ImGui uses the local **khrplatform.h** instead the one in **/usr/include/KHR/khrplatform.h**